### PR TITLE
Implemented BackgroundDataService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ captures/
 */.idea/gradle.xml
 */.idea/assetWizardSettings.xml
 
+# Bridge files
+study_public_key.pem
+
 # Android Studio 3 in .gitignore file.
 .idea/caches
 .idea/modules.xml

--- a/MindKind/app/build.gradle
+++ b/MindKind/app/build.gradle
@@ -145,10 +145,14 @@ dependencies {
     implementation 'androidx.paging:paging-runtime-ktx:2.1.0'
 
     // room db functionality
-    implementation 'androidx.room:room-runtime:2.0.0'
-    kapt 'androidx.room:room-compiler:2.0.0'
-    androidTestImplementation 'androidx.room:room-testing:2.0.0'
-    androidTestImplementation 'androidx.arch.core:core-testing:2.0.0'
+    implementation 'androidx.room:room-runtime:2.2.2'
+    implementation 'androidx.room:room-rxjava2:2.2.2'
+    kapt 'androidx.room:room-compiler:2.2.2'
+    kaptAndroidTest 'androidx.room:room-compiler:2.2.2'
+    androidTestImplementation 'androidx.room:room-testing:2.2.2'
+    implementation 'androidx.room:room-rxjava2:2.2.2'
+    androidTestImplementation 'androidx.arch.core:core-testing:2.1.0'
+    implementation 'androidx.paging:paging-runtime-ktx:2.1.0'
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 

--- a/MindKind/app/src/androidTest/java/org/sagebionetworks/research/mindkind/BackgroundDataRoomTests.kt
+++ b/MindKind/app/src/androidTest/java/org/sagebionetworks/research/mindkind/BackgroundDataRoomTests.kt
@@ -1,0 +1,151 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.sageresearch.viewmodel
+
+import androidx.test.filters.MediumTest
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.joda.time.DateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.sagebionetworks.research.mindkind.RoomTestHelper
+import org.sagebionetworks.research.mindkind.backgrounddata.BackgroundDataType
+import org.sagebionetworks.research.mindkind.room.BackgroundDataEntity
+import org.sagebionetworks.research.sageresearch.dao.room.ReportEntity
+import org.sagebionetworks.research.sageresearch.dao.room.mapValue
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZonedDateTime
+import kotlin.math.exp
+
+@RunWith(AndroidJUnit4::class)
+// ran into multi-dex issues moving this to a library project, leaving it here for now
+@MediumTest
+class BackgroundDataRoomTests: RoomTestHelper() {
+
+    companion object {
+
+        // Noon on 3/7/21
+        private val march7thNoon = LocalDateTime.of(
+                2021,
+                3,
+                7,
+                12,
+                0)
+
+        // 1pm on 3/7/21
+        private val march7th1PM = LocalDateTime.of(
+                2021,
+                3,
+                7,
+                13,
+                0)
+
+        // 2pm on 3/7/21
+        private val march7th2PM = LocalDateTime.of(
+                2021,
+                3,
+                7,
+                14,
+                0)
+
+        private val userPresentData = BackgroundDataEntity(
+                primaryKey = 0,
+                date = march7thNoon,
+                dataType = BackgroundDataType.USER_PRESENT,
+                uploaded = false)
+
+        private val screenOnData = BackgroundDataEntity(
+                primaryKey = 0,
+                date = march7th1PM,
+                dataType = BackgroundDataType.SCREEN_ON,
+                uploaded = false)
+
+        private val screenOffData = BackgroundDataEntity(
+                primaryKey = 0,
+                date = march7th2PM,
+                dataType = BackgroundDataType.SCREEN_OFF,
+                uploaded = true)
+    }
+
+    @Before
+    fun setupForEachTestWithEmptyDatabase() {
+        backgroundDataDao.clear()
+    }
+
+    @Test
+    fun test_clear() {
+        backgroundDataDao.upsert(listOf(screenOnData, screenOffData))
+        backgroundDataDao.clear()
+        assertEquals(0, backgroundDataDao.all().size)
+    }
+
+    @Test
+    fun test_insert1() {
+        val expected = listOf(userPresentData)
+        backgroundDataDao.upsert(expected)
+        val actual = backgroundDataDao.all()
+        assertEqualLists(expected, actual)
+    }
+
+    @Test
+    fun test_insert3_sorted() {
+        val expected = listOf(userPresentData, screenOnData, screenOffData)
+        backgroundDataDao.upsert(expected.reversed()) // Add them in reverse, to "shuffle"
+        val actual = backgroundDataDao.getAllSorted()
+        assertEqualLists(expected, actual)
+    }
+
+    @Test
+    fun test_needs_uploaded() {
+        val expected = listOf(userPresentData, screenOnData)
+        val items = listOf(userPresentData, screenOnData, screenOffData)
+        backgroundDataDao.upsert(items.reversed()) // Add them in reverse, to "shuffle"
+        val actual = backgroundDataDao.getData(false)
+        assertEqualLists(expected, actual)
+    }
+
+    fun assertEqualLists(expected: List<BackgroundDataEntity>, actual: List<BackgroundDataEntity>) {
+        assertEquals(expected.size, actual.size)
+        for (i in expected.indices) {
+            // Don't test primaryKey, it will be different
+            assertEquals(expected[i].dataType, actual[i].dataType)
+            assertEquals(expected[i].dataId, actual[i].dataId)
+            assertEquals(expected[i].date, actual[i].date)
+            assertEquals(expected[i].uploaded, actual[i].uploaded)
+        }
+    }
+}

--- a/MindKind/app/src/androidTest/java/org/sagebionetworks/research/mindkind/RoomTestHelper.kt
+++ b/MindKind/app/src/androidTest/java/org/sagebionetworks/research/mindkind/RoomTestHelper.kt
@@ -1,0 +1,167 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mindkind
+
+import android.icu.util.LocaleData
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.reflect.TypeToken
+import io.reactivex.Flowable
+import junit.framework.Assert.assertNull
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.runner.RunWith
+import org.sagebionetworks.bridge.rest.model.ForwardCursorReportDataList
+import org.sagebionetworks.bridge.rest.model.ReportDataList
+import org.sagebionetworks.bridge.rest.model.ScheduledActivityListV4
+import org.sagebionetworks.research.mindkind.backgrounddata.BackgroundDataType
+import org.sagebionetworks.research.mindkind.room.BackgroundDataEntityDao
+import org.sagebionetworks.research.mindkind.room.MindKindDatabase
+import org.sagebionetworks.research.sageresearch.dao.room.*
+import org.threeten.bp.LocalDate
+import java.io.IOException
+import java.nio.charset.Charset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.jvm.Throws
+
+@RunWith(AndroidJUnit4::class)
+abstract class RoomTestHelper {
+
+    companion object {
+        lateinit var database: MindKindDatabase
+        lateinit var backgroundDataDao: BackgroundDataEntityDao
+
+        @BeforeClass
+        @JvmStatic fun setup() {
+            database = Room.inMemoryDatabaseBuilder(
+                    InstrumentationRegistry.getInstrumentation().getTargetContext(), MindKindDatabase::class.java)
+                    .allowMainThreadQueries().build()
+
+            backgroundDataDao = database.backgroundDataDao()
+        }
+
+        @AfterClass
+        @JvmStatic fun teardown() {
+            database.close()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Throws(InterruptedException::class)
+    fun <T> getValue(liveData: LiveData<T>): T {
+        val data = arrayOfNulls<Any>(1)
+        val latch = CountDownLatch(1)
+        val observer = object : Observer<T> {
+            override fun onChanged(o: T?) {
+                data[0] = o
+                latch.countDown()
+                liveData.removeObserver(this)
+            }
+        }
+        liveData.observeForever(observer)
+        latch.await(1, TimeUnit.SECONDS)
+
+        return data[0] as T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Throws(InterruptedException::class)
+    fun <T> getValue(flowable: Flowable<List<T>>): T {
+        val data = arrayOfNulls<Any>(1)
+        val latch = CountDownLatch(1)
+        flowable.subscribe {
+            if (!it.isEmpty()) {
+                data[0] = it.get(0)
+            }
+            latch.countDown()
+        }
+        latch.await(1, TimeUnit.SECONDS)
+
+        return data[0] as T
+    }
+}
+
+object TestResourceHelper {
+
+    val entityTypeConverters = EntityTypeConverters()
+
+    fun testResourceMap(resourceSet: Set<String>): Map<String, List<ScheduledActivityEntity>> {
+        return resourceSet.associateBy( {it}, {
+            testResource(it)
+        } )
+    }
+
+    internal fun testResource(filename: String): List<ScheduledActivityEntity> {
+        val json = testResourceJson(filename)
+        val testList = entityTypeConverters.bridgeGson.fromJson(json, ScheduledActivityListV4::class.java)
+        return EntityTypeConverters().fromScheduledActivityListV4(testList) ?: ArrayList()
+    }
+
+    fun testResourceForwardCursorReportDataList(filename: String): ForwardCursorReportDataList {
+        val json = testResourceJson(filename)
+        return entityTypeConverters.bridgeGson.fromJson(json, ForwardCursorReportDataList::class.java)
+    }
+
+    fun testResourceReportDataList(filename: String): ReportDataList {
+        val json = testResourceJson(filename)
+        return entityTypeConverters.bridgeGson.fromJson(json, ReportDataList::class.java)
+    }
+
+    fun testResourceReportEntityList(filename: String): List<ReportEntity> {
+        val json = testResourceJson(filename)
+        val listType = object : TypeToken<List<ReportEntity>>() {}.type
+        return entityTypeConverters.bridgeGson.fromJson(json, listType)
+    }
+
+    // This removes auto-generated by AS for getting a class' classLoader
+    @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+    internal fun testResourceJson(filename: String): String {
+        var json: String? = null
+        try {
+            val inputStream = RoomTestHelper::class.java.classLoader
+                    ?.getResourceAsStream(filename) ?: return "Error reading stream"
+            val size = inputStream.available()
+            val buffer = ByteArray(size)
+            inputStream.read(buffer)
+            inputStream.close()
+            json = String(buffer, Charset.defaultCharset())
+        } catch (e: IOException) {
+            assertNull("Error loading class resource", e)
+        }
+        return json ?: ""
+    }
+}

--- a/MindKind/app/src/main/AndroidManifest.xml
+++ b/MindKind/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.sagebionetworks.research.mindkind">
 
+    <!-- Needed for BackgroundDataService.kt to show a foreground notification -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application
         android:name="org.sagebionetworks.research.mindkind.MindKindApplication"
         android:allowBackup="false"
@@ -20,6 +23,11 @@
             android:multiprocess="true"
             tools:node="remove"
             tools:targetApi="n" />
+
+        <service
+            android:name=".backgrounddata.BackgroundDataService"
+            android:exported="false"
+            android:label="Background Data Service"/>
 
         <activity
             android:name=".EntryActivity"

--- a/MindKind/app/src/main/assets/task_to_schema.json
+++ b/MindKind/app/src/main/assets/task_to_schema.json
@@ -1,2 +1,6 @@
 {
+  "BackgroundData": {
+    "id": "BackgroundData",
+    "revision": 1
+  }
 }

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/backgrounddata/BackgroundData.kt
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/backgrounddata/BackgroundData.kt
@@ -1,0 +1,115 @@
+
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mindkind.backgrounddata
+
+import androidx.room.TypeConverter
+import com.google.gson.GsonBuilder
+import org.joda.time.DateTime
+import org.sagebionetworks.bridge.rest.gson.ByteArrayToBase64TypeAdapter
+import org.sagebionetworks.bridge.rest.gson.DateTimeTypeAdapter
+import org.sagebionetworks.bridge.rest.gson.LocalDateTypeAdapter
+import org.sagebionetworks.research.sageresearch.dao.room.*
+import org.threeten.bp.*
+
+open class BackgroundDataTypeConverters {
+
+    companion object {
+        private const val TAG = "BackgroundDataTypeConverters"
+    }
+
+    val gsonBuilder = GsonBuilder()
+            .registerTypeAdapter(ByteArray::class.java, ByteArrayToBase64TypeAdapter())
+            .registerTypeAdapter(org.joda.time.LocalDate::class.java, LocalDateTypeAdapter())
+            .registerTypeAdapter(DateTime::class.java, DateTimeTypeAdapter())
+            .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
+            .registerTypeAdapter(ZonedDateTime::class.java, ZonedDateTimeAdapter())
+            .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+            .registerTypeAdapter(Instant::class.java, InstantAdapter())
+
+    val gson = gsonBuilder.create()
+
+    @TypeConverter
+    fun toBackgroundDataType(value: String) = enumValueOf<BackgroundDataType>(value)
+
+    @TypeConverter
+    fun fromBackgroundDataType(value: BackgroundDataType) = value.name
+
+    @TypeConverter
+    fun fromLocalDateString(value: String?): LocalDate? {
+        val valueChecked = value ?: return null
+        return LocalDate.parse(valueChecked)
+    }
+
+    @TypeConverter
+    fun fromLocalDate(value: LocalDate?): String? {
+        val valueChecked = value ?: return null
+        return valueChecked.toString()
+    }
+
+    @TypeConverter
+    fun fromLocalDateTimeString(value: String?): LocalDateTime? {
+        val valueChecked = value ?: return null
+        return LocalDateTime.parse(valueChecked)
+    }
+
+    @TypeConverter
+    fun fromLocalDateTime(value: LocalDateTime?): String? {
+        val valueChecked = value ?: return null
+        return valueChecked.toString()
+    }
+
+    @TypeConverter
+    fun fromInstant(value: Long?): Instant? {
+        val valueChecked = value ?: return null
+        return Instant.ofEpochMilli(valueChecked)
+    }
+
+    @TypeConverter
+    fun fromInstantTimestamp(value: Instant?): Long? {
+        val valueChecked = value ?: return null
+        return valueChecked.toEpochMilli()
+    }
+
+    @TypeConverter
+    fun fromLocalTime(value: Long?): LocalTime? {
+        val valueChecked = value ?: return null
+        return LocalTime.ofNanoOfDay(valueChecked)
+    }
+
+    @TypeConverter
+    fun fromLocalTimeStamp(value: LocalTime?): Long? {
+        val valueChecked = value ?: return null
+        return valueChecked.toNanoOfDay()
+    }
+}

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/backgrounddata/BackgroundDataService.kt
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/backgrounddata/BackgroundDataService.kt
@@ -1,0 +1,422 @@
+
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mindkind.backgrounddata
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.NotificationManager.IMPORTANCE_LOW
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.Builder
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.room.Room
+import dagger.android.DaggerService
+import io.reactivex.Completable
+import io.reactivex.Scheduler
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+import org.sagebionetworks.research.domain.Schema
+import org.sagebionetworks.research.domain.result.implementations.FileResultBase
+import org.sagebionetworks.research.domain.result.implementations.TaskResultBase
+import org.sagebionetworks.research.domain.result.interfaces.Result
+import org.sagebionetworks.research.mindkind.R
+import org.sagebionetworks.research.mindkind.R.drawable
+import org.sagebionetworks.research.mindkind.R.string
+import org.sagebionetworks.research.mindkind.research.SageTaskIdentifier
+import org.sagebionetworks.research.mindkind.room.BackgroundDataEntity
+import org.sagebionetworks.research.mindkind.room.MindKindDatabase
+import org.sagebionetworks.research.presentation.perform_task.TaskResultManager
+import org.sagebionetworks.research.presentation.perform_task.TaskResultProcessingManager
+import org.sagebionetworks.research.sageresearch.extensions.toInstant
+import org.sagebionetworks.research.sageresearch_app_sdk.TaskResultUploader
+import org.threeten.bp.Instant
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneId
+import org.threeten.bp.temporal.ChronoUnit
+import java.io.File
+import java.util.*
+import javax.inject.Inject
+
+class BackgroundDataService : DaggerService() {
+
+    companion object {
+        public const val UPLOAD_DATA_ACTION = "UPLOAD_DATA_TO_BRIDGE_ACTION"
+        public const val BACKGROUND_DATA_DB_FILENAME = "org.sagebionetworks.research.MindKind.BackgroundData"
+        private const val TAG = "BackgroundDataService"
+        private const val TASK_IDENTIFIER = SageTaskIdentifier.BACKGROUND_DATA
+        private const val FOREGROUND_NOTIFICATION_ID = 100
+        private const val JSON_MIME_CONTENT_TYPE = "application/json"
+
+        // True when this service is running, false otherwise
+        public var isServiceRunning = false
+
+        private fun createMinuteRateLimit(): RateLimiter {
+            return RateLimiter(1000L * 60L)
+        }
+    }
+
+    private var taskUUID = UUID.randomUUID()
+    private val taskIdentifier = SageTaskIdentifier.BACKGROUND_DATA
+
+    lateinit var database: MindKindDatabase
+
+    @Inject
+    lateinit var taskResultManager: TaskResultManager
+
+    @Inject
+    lateinit var taskResultProcessingManager: TaskResultProcessingManager
+
+    @Inject
+    lateinit var taskResultUploader: TaskResultUploader
+
+    private val compositeDisposable = CompositeDisposable()
+    /**
+     * Subscribes to the completable using the CompositeDisposable
+     * This is open for unit testing purposes to to run a blockingGet() instead of an asynchronous subscribe
+     */
+    @VisibleForTesting
+    protected open fun subscribeCompletableAsync(
+            completable: Completable, successMsg: String, errorMsg: String) {
+
+        compositeDisposable.add(completable
+                .subscribeOn(asyncScheduler)
+                .subscribe({
+                    Log.i(TAG, successMsg)
+                }, {
+                    Log.w(TAG, "$errorMsg ${it.localizedMessage}")
+                }))
+    }
+    /**
+     * @property asyncScheduler for performing network and database operations
+     */
+    @VisibleForTesting
+    protected open val asyncScheduler: Scheduler get() = Schedulers.io()
+
+    private val receiver = BackgroundDataReceiver()
+
+    private val noRateLimit = NoLimitRateLimiter()
+    private val batterChangedLimiter = createMinuteRateLimit()
+
+    override fun onCreate() {
+        Log.d(TAG, "onCreate")
+        super.onCreate()
+
+        isServiceRunning = true
+        startForeground()
+
+        database = Room.databaseBuilder(this,
+                MindKindDatabase::class.java,
+                BACKGROUND_DATA_DB_FILENAME)
+                /* .addMigrations(*migrations) */
+                .build()
+
+        // Register broadcast receivers
+        val filter = IntentFilter(Intent.ACTION_USER_PRESENT).apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_BATTERY_CHANGED)
+            addAction(Intent.ACTION_POWER_CONNECTED)
+            addAction(Intent.ACTION_POWER_DISCONNECTED)
+        }
+        registerReceiver(receiver, filter)
+
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+                uploadDataReceiver, IntentFilter(UPLOAD_DATA_ACTION))
+    }
+
+    override fun onDestroy() {
+        Log.d(TAG, "onDestroy")
+
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(uploadDataReceiver)
+        unregisterReceiver(receiver)
+        compositeDisposable.clear()
+        stopForeground(true)
+
+        isServiceRunning = false
+
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        Log.d(TAG, "onBind")
+        return null
+    }
+
+    private val uploadDataReceiver: BroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            uploadDataToBridge()
+        }
+    }
+
+    private fun uploadDataToBridge() {
+
+        val completable = Completable.fromAction {
+            val dataToUpload =
+                    database.backgroundDataDao().getData(false)
+
+            if (dataToUpload.isEmpty()) {
+                return@fromAction
+            }
+
+            val taskResultBase = createTaskResult(dataToUpload)
+
+            // Upload task result
+            subscribeCompletableAsync(
+                    taskResultUploader.processTaskResult(taskResultBase),
+                    "Successfully uploaded task result to bridge",
+                    "Failed to upload task result to bridge")
+
+            // Write database changes
+            dataToUpload.forEach {
+                it.uploaded = true
+            }
+            database.backgroundDataDao().upsert(dataToUpload)
+
+        } .doOnError {
+            Log.w(TAG, it.localizedMessage ?: "")
+        }
+
+        subscribeCompletableAsync(completable,
+                "Successfully saved BackgroundData to room",
+                "Failed to save BackgroundData to room")
+    }
+
+    private fun createTaskResult(backgroundData: List<BackgroundDataEntity>): TaskResultBase {
+        val startTime = backgroundData.firstOrNull()?.date
+                ?.toInstant(ZoneId.systemDefault()) ?: Instant.now()
+        val endTime = backgroundData.lastOrNull()?.date
+                ?.toInstant(ZoneId.systemDefault()) ?: Instant.now()
+
+        val json = BackgroundDataTypeConverters().gson.toJson(backgroundData)
+        openFileOutput("data.json", Context.MODE_PRIVATE).use {
+            it.write(json.toByteArray())
+        }
+
+        val jsonFileResult = FileResultBase("data",
+                startTime, endTime, JSON_MIME_CONTENT_TYPE, filesDir.path + File.separator + "data.json")
+
+        var taskResultBase = TaskResultBase(TASK_IDENTIFIER, startTime,
+                endTime, UUID.randomUUID(), Schema(TASK_IDENTIFIER, 1),
+                mutableListOf(), mutableListOf())
+
+        taskResultBase = taskResultBase.addStepHistory(jsonFileResult)
+        return taskResultBase
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "onStartCommand: startId = $startId")
+
+//        START_STICKY- tells the system to create a fresh copy of the service,
+//        when sufficient memory is available, after it recovers from low memory.
+//        Here you will lose the results that might have computed before.
+//
+//        START_NOT_STICKY- tells the system not to bother to restart the service,
+//        even when it has sufficient memory.
+//
+//        START_REDELIVER_INTENT- tells the system to restart the service after the crash
+//                and also redeliver the intents that were present at the time of crash.
+
+        return START_STICKY
+    }
+
+    private fun startForeground() {
+        createNotificationChannel()
+        val notification = createNotification(
+                "Monitoring for data changes.  We only collect data you have consented to sharing.")
+        startForeground(FOREGROUND_NOTIFICATION_ID, notification)
+    }
+
+    private fun createNotification(text: String? = null): Notification {
+        return Builder(this, getString(string.foreground_channel_id))
+                .setContentTitle("MindKind Study")
+                .setContentText(text ?: "")
+                .setSmallIcon(
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                            drawable.ic_launcher_foreground else R.mipmap.ic_launcher)
+                .setStyle(NotificationCompat.BigTextStyle()
+                        .bigText(text ?: ""))
+                .build()
+    }
+
+    private fun updateNotification(text: String) {
+        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .notify(FOREGROUND_NOTIFICATION_ID, createNotification(text))
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create the NotificationChannel
+            val title = getString(string.foreground_channel_title)
+            val desc = getString(string.foreground_channel_desc)
+            val importance = NotificationManager.IMPORTANCE_LOW
+            val mChannel = NotificationChannel(getString(string.foreground_channel_id), title, importance)
+            mChannel.description = desc
+            mChannel.importance = IMPORTANCE_LOW
+            // Register the channel with the system; can't change importance or other behaviors after this
+            (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(mChannel)
+        }
+    }
+
+    /**
+     * Some broadcast receivers are called too frequently and need rate limited
+     * to avoid constantly writing to the database and draining the user's battery
+     * @param dataType to rate limit
+     */
+    fun rateLimiterFor(dataType: BackgroundDataType): RateLimiter {
+        return when(dataType) {
+            BackgroundDataType.BATTERY_PERCENTAGE -> batterChangedLimiter
+            else -> noRateLimit
+        }
+    }
+
+    /**
+     * Writes background data to room asynchronously
+     * @param backgroundData to add to room
+     */
+    fun writeBackgroundDataToRoom(backgroundData: BackgroundDataEntity) {
+        val completable = Completable.fromAction {
+            database.backgroundDataDao().upsert(listOf(backgroundData))
+        } .doOnError {
+            Log.w(TAG, it.localizedMessage ?: "")
+        }
+        subscribeCompletableAsync(completable,
+                "Successfully saved BackgroundData to room",
+                "Failed to save BackgroundData to room")
+    }
+
+    inner class BackgroundDataReceiver : BroadcastReceiver() {
+
+        override fun onReceive(ctx: Context, intent: Intent) {
+            val dataType = BackgroundDataType.from(intent) ?: run {
+                Log.e(TAG, "Error creating data type from intent action")
+                return
+            }
+
+            val now = LocalDateTime.now()
+
+            // Check if we should rate-limit this data type
+            if (rateLimiterFor(dataType).shouldLimit(now)) {
+                return
+            }
+
+            val backgroundData = BackgroundDataEntity(
+                    date = now,
+                    dataType = dataType,
+                    uploaded = false)
+
+            writeBackgroundDataToRoom(backgroundData)
+
+            // Do dataType specific operations
+            when(intent.action) {
+                Intent.ACTION_BATTERY_CHANGED -> onReceiveBatteryChanged(intent)
+                else -> onReceiveDefaultActionChanged(intent)
+            }
+        }
+
+        private fun onReceiveDefaultActionChanged(intent: Intent) {
+            Log.d(TAG, "Received ${intent.action}")
+        }
+
+        private fun onReceiveBatteryChanged(intent: Intent) {
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            val batteryPct = level * 100 / scale.toFloat()
+            Log.d(TAG, "Received $batteryPct% ${intent.action}")
+            // TODO: mdephillips 3/7/21 save battery percentage entity in its own table
+        }
+    }
+}
+
+open class NoLimitRateLimiter: RateLimiter(0) {
+    override fun shouldLimit(eventTime: LocalDateTime): Boolean {
+        return false
+    }
+}
+
+open class RateLimiter(val limitTime: Long) {
+    var lastEventTime: LocalDateTime? = null
+    /**
+     * @param eventTime time of event to possibly limit
+     * @return if eventTime should be limited or not.
+     *          note: if returning true, eventTime will
+     *          be used as limit time on next function call
+     */
+    open fun shouldLimit(eventTime: LocalDateTime): Boolean {
+        val last = lastEventTime ?: run {
+            lastEventTime = LocalDateTime.now()
+            return false
+        }
+        if (ChronoUnit.MILLIS.between(last, eventTime) > limitTime) {
+            lastEventTime = LocalDateTime.now()
+            return false
+        }
+        return true
+    }
+}
+
+public enum class BackgroundDataType(val type: String) {
+    SCREEN_ON("Screen_On"),
+    SCREEN_OFF("Screen_Off"),
+    USER_PRESENT("User_Present"),
+    BATTERY_PERCENTAGE("Battery_Percentage"),
+    POWER_CONNECTED("Power_Connected"),
+    POWER_DISCONNECTED("Power_Disconnected");
+
+    companion object {
+        /**
+         * @return the background data type for the action
+         */
+        fun from(intent: Intent): BackgroundDataType? {
+            val action = intent.action ?: run { return null }
+            return when(action) {
+                Intent.ACTION_BATTERY_CHANGED -> BATTERY_PERCENTAGE
+                Intent.ACTION_SCREEN_ON -> SCREEN_ON
+                Intent.ACTION_SCREEN_OFF -> SCREEN_OFF
+                Intent.ACTION_USER_PRESENT -> USER_PRESENT
+                Intent.ACTION_POWER_CONNECTED -> POWER_CONNECTED
+                Intent.ACTION_POWER_DISCONNECTED -> POWER_DISCONNECTED
+                else -> null
+            }
+        }
+    }
+}

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/inject/SageAppModule.java
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/inject/SageAppModule.java
@@ -32,6 +32,7 @@
 
 package org.sagebionetworks.research.mindkind.inject;
 
+import org.sagebionetworks.research.mindkind.backgrounddata.BackgroundDataService;
 import org.sagebionetworks.research.mobile_ui.perform_task.PerformTaskActivity;
 
 import dagger.Module;
@@ -44,4 +45,7 @@ public abstract class SageAppModule {
 
     @ContributesAndroidInjector
     abstract PerformTaskActivity contributePerformTaskActivityInjector();
+
+    @ContributesAndroidInjector
+    abstract BackgroundDataService contributeBackgroundDataService();
 }

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/research/SageTaskIdentifier.java
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/research/SageTaskIdentifier.java
@@ -38,7 +38,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.SOURCE)
-@StringDef({SageTaskIdentifier.PHQ9})
+@StringDef({
+        SageTaskIdentifier.PHQ9,
+        SageTaskIdentifier.GAD7,
+        SageTaskIdentifier.BACKGROUND_DATA })
+
 public @interface SageTaskIdentifier {
     String PHQ9 = "PHQ9";
+    String GAD7 = "GAD7";
+    String BACKGROUND_DATA = "BackgroundData";
 }

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/room/BackgroundDataEntity.kt
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/room/BackgroundDataEntity.kt
@@ -1,0 +1,105 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mindkind.room
+
+import androidx.annotation.VisibleForTesting
+import androidx.room.*
+import com.google.gson.annotations.SerializedName
+import org.joda.time.DateTime
+import org.sagebionetworks.research.mindkind.backgrounddata.BackgroundDataType
+import org.threeten.bp.LocalDateTime
+
+/**
+ * The BackgroundDataEntity contains a piece of data that was collected from the user
+ * during the execution of the BackgroundDataService.
+ */
+@Entity
+data class BackgroundDataEntity(
+        /**
+         * @property primaryKey
+         */
+        @PrimaryKey(autoGenerate = true) var primaryKey: Int = 0,  // 0 signals to room to auto-generate the id
+        /**
+         * @property date when the background data was collected
+         */
+        @ColumnInfo(index = true)
+        var date: LocalDateTime? = null,
+        /**
+         * @property type of the background data
+         */
+        @ColumnInfo(index = true)
+        var dataType: BackgroundDataType? = null,
+        /**
+         * @property uploaded if this background data has been packaged for upload already
+         */
+        @ColumnInfo(index = true)
+        var uploaded: Boolean = false,
+        /**
+         * @property data id which is the primary key of the specified data within the type entity
+         */
+        @SerializedName("data")
+        var dataId: Int = 0)
+
+@Dao
+interface BackgroundDataEntityDao {
+
+        /**
+         * This may take a long time and use a lot of memory if the table is large, call with caution
+         * @return all the reports in the table
+         */
+        @VisibleForTesting
+        @Query(RoomSqlHelper.BACKGROUND_DATA_QUERY_ALL)
+        fun all(): List<BackgroundDataEntity>
+
+        @VisibleForTesting
+        @Query(RoomSqlHelper.BACKGROUND_DATA_QUERY_ALL_SORTED)
+        fun getAllSorted(): List<BackgroundDataEntity>
+
+        /**
+         * @param BackgroundDataEntityList to insert into the database
+         */
+        @Insert(onConflict = OnConflictStrategy.REPLACE)
+        fun upsert(BackgroundDataEntityList: List<BackgroundDataEntity>)
+
+        /**
+         * @return All the background data that has not been uploaded yet
+         */
+        @Query(RoomSqlHelper.BACKGROUND_DATA_QUERY_IS_UPLOADED)
+        fun getData(isUploaded: Boolean): List<BackgroundDataEntity>
+
+        /**
+         * Deletes all rows in the table.  To be called on sign out or a cache clear.
+         */
+        @Query(RoomSqlHelper.BACKGROUND_DATA_DELETE)
+        fun clear()
+}

--- a/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/room/MindKindDatabase.kt
+++ b/MindKind/app/src/main/java/org/sagebionetworks/research/mindkind/room/MindKindDatabase.kt
@@ -1,0 +1,166 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2021  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mindkind.room
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import org.sagebionetworks.research.mindkind.backgrounddata.BackgroundDataTypeConverters
+import org.sagebionetworks.research.sageresearch.dao.room.*
+
+/**
+ * To keep track of database changes, use this comment group as a change log
+ * Version 1 - BackgroundDataEntity table created and added
+ */
+@Database(entities = [
+    BackgroundDataEntity::class],
+        version = 1)
+
+@TypeConverters(BackgroundDataTypeConverters::class)
+abstract class MindKindDatabase : RoomDatabase() {
+
+    // Room will automatically setup up this DAO
+    abstract fun backgroundDataDao(): BackgroundDataEntityDao
+
+    companion object {
+        /**
+         * @param tableName to add the index to
+         * @param fieldName to add the index to
+         * @return the SQL command to add an index to a field name in a table
+         */
+        private fun migrationAddIndex(tableName: String, fieldName: String): String {
+            return "CREATE INDEX index_${tableName}_$fieldName ON $tableName ($fieldName)"
+        }
+    }
+
+   /**
+    * We will probably need to migrate version at some point,
+    * If we do, here are some examples:
+    *
+    *   val migrations: Array<Migration> get() = arrayOf(
+    *       object : Migration(1, 2) {
+    *           override fun migrate(database: SupportSQLiteDatabase) {
+    *               val reportTable = "ReportEntity"
+    *               // Create the ReportEntity table
+    *               // This can be copy/pasted from "2.json" or whatever version database was created
+    *               database.execSQL("CREATE TABLE `$reportTable` " +
+    *                       "(`primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+    *                       "`identifier` TEXT, " +
+    *                       "`data` TEXT, " +
+    *                       "`dateTime` INTEGER, " +
+    *                       "`localDate` TEXT, " +
+    *                       "`needsSyncedToBridge` INTEGER)")
+    *               // If indexes are specified for a field name, they need to be added separately
+    *               database.execSQL(migrationAddIndex(reportTable, "identifier"))
+    *               database.execSQL(migrationAddIndex(reportTable, "dateTime"))
+    *               database.execSQL(migrationAddIndex(reportTable, "localDate"))
+    *               database.execSQL(migrationAddIndex(reportTable, "needsSyncedToBridge"))
+    *           }
+    *       },
+    *       object : Migration(2, 3) {
+    *           override fun migrate(database: SupportSQLiteDatabase) {
+    *               val reportTable = "ResourceEntity"
+    *               database.execSQL("CREATE TABLE `ResourceEntity` (`identifier` TEXT NOT NULL, `type` TEXT NOT NULL, `resourceJson` TEXT, `lastUpdateTime` INTEGER NOT NULL, PRIMARY KEY(`identifier`, `type`))")
+    *               database.execSQL("CREATE  INDEX `index_ResourceEntity_type` ON `ResourceEntity` (`type`)")
+    *           }
+    *       },
+    *       object : Migration(3, 4) {
+    *           override fun migrate(database: SupportSQLiteDatabase) {
+    *               val tableName = "HistoryItemEntity"
+    *               database.execSQL("CREATE TABLE IF NOT EXISTS `${tableName}` (`type` TEXT NOT NULL, `dataJson` TEXT NOT NULL, `reportId` TEXT NOT NULL, `dateBucket` TEXT NOT NULL, `dateTime` INTEGER NOT NULL, `time` INTEGER NOT NULL, PRIMARY KEY(`reportId`, `dateBucket`, `time`))")
+    *           }
+    *       })
+    */
+}
+
+internal class RoomSqlHelper {
+    /**
+     * Because all Room queries need to be verified at compile time, we cannot build dynamic queries based on state.
+     * This is where these constant string values come into play, as building blocks to form reliable Room queries.
+     * These originally came about to model re-usable query components like iOS' NSPredicates and CoreData.
+     */
+    companion object RoomSqlConstants {
+
+        /**
+         * OP constants combing CONDITION constants
+         */
+        private const val OP_AND = " AND "
+        private const val OP_OR = " OR "
+
+        /**
+         * DELETE constants delete tables
+         */
+        const val BACKGROUND_DATA_DELETE = "DELETE FROM backgrounddataentity"
+        const val BACKGROUND_DATA_DELETE_WHERE = "DELETE FROM backgrounddataentity WHERE "
+
+        /**
+         * SELECT constants start off queries
+         */
+        private const val BACKGROUND_DATA_SELECT = "SELECT * FROM backgrounddataentity WHERE "
+
+        /**
+         * ORDER BY constants do sorting on queries
+         */
+        private const val ORDER_BY_DATE_OLDEST = " ORDER BY date ASC"
+
+        /**
+         * LIMIT constants restrict the number of db rows
+         */
+        private const val LIMIT_1 = " LIMIT 1"
+
+        /**
+         * CONDITION constants need to be joined by AND or OR in the select statement
+         */
+        private const val BACKGROUND_DATA_CONDITION_UPLOADED = "(uploaded = :isUploaded)"
+        private const val BACKGROUND_DATA_CONDITION_TYPE = "(dataType = :dataType)"
+        private const val BACKGROUND_DATA_CONDITION_DATE_BETWEEN = "(date BETWEEN :start AND :end)"
+
+        const val BACKGROUND_DATA_CONDITION_BETWEEN_DATE_WITH_TYPE =
+                BACKGROUND_DATA_CONDITION_TYPE + OP_AND +
+                        BACKGROUND_DATA_CONDITION_DATE_BETWEEN
+
+        /**
+         * QUERY constants are full Room queries
+         */
+        const val BACKGROUND_DATA_QUERY_ALL = "SELECT * FROM backgrounddataentity"
+
+        const val BACKGROUND_DATA_QUERY_ALL_SORTED =
+                BACKGROUND_DATA_QUERY_ALL + ORDER_BY_DATE_OLDEST
+
+        const val BACKGROUND_DATA_QUERY_IS_UPLOADED =
+                BACKGROUND_DATA_SELECT + BACKGROUND_DATA_CONDITION_UPLOADED +
+                        ORDER_BY_DATE_OLDEST
+    }
+}

--- a/MindKind/app/src/main/res/layout/fragment_task_list.xml
+++ b/MindKind/app/src/main/res/layout/fragment_task_list.xml
@@ -11,6 +11,26 @@
     android:padding="@dimen/margin_medium">
 
     <Button
+        android:id="@+id/buttonBackgroundData"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:ignore="HardcodedText"
+        android:text="Start passive data"
+        android:textSize="@dimen/rsb_text_size_title"
+        android:layout_marginBottom="@dimen/margin_medium"
+        android:layout_above="@+id/buttonUploadData"/>
+
+    <Button
+        android:id="@+id/buttonUploadData"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:ignore="HardcodedText"
+        android:text="Upload to Bridge"
+        android:textSize="@dimen/rsb_text_size_title"
+        android:layout_marginBottom="@dimen/margin_medium"
+        android:layout_above="@+id/buttonPhq9"/>
+
+    <Button
         android:id="@+id/buttonPhq9"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/MindKind/app/src/main/res/values/strings.xml
+++ b/MindKind/app/src/main/res/values/strings.xml
@@ -59,9 +59,9 @@
     <string name="reminder_notification_channel_title">mPower Reminders</string>
     <string name="reminder_notification_channel_desc">mPower reminders help you remember to log your data</string>
 
-    <string name="foreground_channel_id">mPower Alerts</string>
-    <string name="foreground_channel_title">mPower Informational Alerts</string>
-    <string name="foreground_channel_desc">mPower low importance informational alerts</string>
+    <string name="foreground_channel_id">MindKind Passive Data</string>
+    <string name="foreground_channel_title">MindKind Passive Data Collection</string>
+    <string name="foreground_channel_desc">The MindKind Study needs a foreground notification to allow our study app to be notified when your data changes.</string>
 
     <string-array name="days_of_the_week">
         <item>Sunday</item>


### PR DESCRIPTION
This PR adds in the bones for the passive data (background data) collection foreground service.  When you start the service, it collects data on these BroadcastReceivers:

addAction(Intent.ACTION_SCREEN_ON)
addAction(Intent.ACTION_SCREEN_OFF)
addAction(Intent.ACTION_BATTERY_CHANGED)
addAction(Intent.ACTION_POWER_CONNECTED)
addAction(Intent.ACTION_POWER_DISCONNECTED)

Every time one is fired, it writes the data type and timestamp to the room database.  The only one that needed "rate limited" was battery_changed events, which I limited to every minute max for now.

Uploading to bridge has been tested, and you can see the results in [Background Table](https://www.synapse.org/#!Synapse:syn25144943/tables/) in Synapse.


@rianhouston  @EricSiegNW  see comments to guide you through the Database changes.