### PR TITLE
bintray_fix

### DIFF
--- a/MindKind/.idea/jarRepositories.xml
+++ b/MindKind/.idea/jarRepositories.xml
@@ -51,5 +51,10 @@
       <option name="name" value="maven4" />
       <option name="url" value="https://dl.bintray.com/sage-bionetworks/research-stack/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://sagebionetworks.jfrog.io/artifactory/mobile-sdks/" />
+    </remote-repository>
   </component>
 </project>

--- a/MindKind/build.gradle
+++ b/MindKind/build.gradle
@@ -42,11 +42,9 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://dl.bintray.com/touchlab/Squeaky" }
         maven { url "https://jitpack.io" }
         maven { url 'http://repo-maven.sagebridge.org/' }
-        maven { url 'https://dl.bintray.com/sage-bionetworks/research-stack/' } // remove after added to mavenCentral
-        maven { url 'https://dl.bintray.com/sage-bionetworks/bridge-maven-release/' } // remove after added to mavenCentral
+        maven { url "https://sagebionetworks.jfrog.io/artifactory/mobile-sdks/" }
         mavenLocal()
     }
 }


### PR DESCRIPTION
Bintray as a service is discontinued and our apps do not compile pointed at the old maven location.  National updated to the new way to host artifacts, so this makes our app compile again.